### PR TITLE
Guard monitor 'Weather' behind flag 'with_weather'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -160,9 +160,13 @@ Otherwise, you'll need to install them yourself.
 `with_uvmeter`
 :    Enables UVMeter plugin. The plugin shows UV data for Australia.
 
+`with_weather`
+:    Support to display weather information. Enables Weather plugin.
+
 `with_conduit`
 :    Use http-conduit for getting weather data enabling support for http proxies.
      Requires [http-conduit] and [http-types].
+     Note that this flag has only an effect if `with_weather` is also set.
 
 `all_extensions`
 :    Enables all the extensions above.

--- a/src/Plugins/Monitors.hs
+++ b/src/Plugins/Monitors.hs
@@ -20,7 +20,9 @@ module Plugins.Monitors where
 import Plugins
 
 import Plugins.Monitors.Common (runM, runMD)
+#ifdef WEATHER
 import Plugins.Monitors.Weather
+#endif
 import Plugins.Monitors.Net
 import Plugins.Monitors.Mem
 import Plugins.Monitors.Swap
@@ -53,8 +55,7 @@ import Plugins.Monitors.Volume
 import Plugins.Monitors.Mpris
 #endif
 
-data Monitors = Weather      Station     Args Rate
-              | Network      Interface   Args Rate
+data Monitors = Network      Interface   Args Rate
               | DynNetwork               Args Rate
               | BatteryP     Args        Args Rate
               | BatteryN     Args        Args Rate Alias
@@ -74,6 +75,9 @@ data Monitors = Weather      Station     Args Rate
               | TopMem       Args        Rate
               | Uptime       Args        Rate
               | CatInt       Int FilePath Args Rate
+#ifdef WEATHER
+              | Weather      Station     Args Rate
+#endif
 #ifdef UVMETER
               | UVMeter      Station     Args Rate
 #endif
@@ -104,7 +108,9 @@ type Rate      = Int
 type DiskSpec  = [(String, String)]
 
 instance Exec Monitors where
+#ifdef WEATHER
     alias (Weather s _ _) = s
+#endif
     alias (Network i _ _) = i
     alias (DynNetwork _ _) = "dynnetwork"
     alias (Thermal z _ _) = z
@@ -148,7 +154,9 @@ instance Exec Monitors where
     start (MultiCpu a r) = startMultiCpu a r
     start (TopProc a r) = startTop a r
     start (TopMem a r) = runM a topMemConfig runTopMem r
+#ifdef WEATHER
     start (Weather s a r) = runMD (a ++ [s]) weatherConfig runWeather r weatherReady
+#endif
     start (Thermal z a r) = runM (a ++ [z]) thermalConfig runThermal r
     start (ThermalZone z a r) =
       runM (a ++ [show z]) thermalZoneConfig runThermalZone r

--- a/xmobar.cabal
+++ b/xmobar.cabal
@@ -82,8 +82,12 @@ flag with_uvmeter
   description: UVMeter only useful to australians.
   default: False
 
+flag with_weather
+  description: Enable weather plugin
+  default: False
+
 flag with_conduit
-  description: Use http-conduits for getting weather data
+  description: Use http-conduits for getting weather data, only has an effect if with_weather is set.
   default: False
 
 executable xmobar
@@ -105,7 +109,7 @@ executable xmobar
       Plugins.Monitors.MultiCpu, Plugins.Monitors.Net,
       Plugins.Monitors.Swap, Plugins.Monitors.Thermal,
       Plugins.Monitors.ThermalZone, Plugins.Monitors.Top,
-      Plugins.Monitors.Uptime, Plugins.Monitors.Weather,
+      Plugins.Monitors.Uptime,
       Plugins.Monitors.Bright, Plugins.Monitors.CatInt,
       Plugins.Monitors.UVMeter
 
@@ -127,13 +131,7 @@ executable xmobar
       X11 >= 1.6.1,
       mtl >= 2.1 && < 2.3,
       parsec == 3.1.*,
-      HTTP >= 4000.2.4,
       stm >= 2.3 && < 2.5
-
-    if flag(with_conduit)
-       -- use http-conduit  instead of simple-http
-       build-depends: http-conduit, http-types
-       cpp-options: -DHTTP_CONDUIT
 
     if flag(with_threaded)
        -- -threaded is a workaround for 100% CPU busy loop
@@ -194,6 +192,15 @@ executable xmobar
        extra-libraries: Xpm
        other-modules: XPMFile
        cpp-options: -DXPM
+
+    if flag(with_weather) || flag(all_extensions)
+       build-depends: HTTP >= 4000.2.4
+       other-modules: Plugins.Monitors.Weather
+       cpp-options: -DWEATHER
+       if flag(with_conduit)
+          -- use http-conduit  instead of simple-http
+          build-depends: http-conduit, http-types
+          cpp-options: -DHTTP_CONDUIT
 
     if flag(with_uvmeter)
        cpp-options: -DUVMETER


### PR DESCRIPTION
Guard monitor 'Weather' behind flag 'with_weather'

Hide the monitor 'Weather' behind a flag named 'with_weather'.
This implies that the dependency on the module 'HTTP' is now optional.

Further moved the effect of the flag with_conduit within the branch of
'with_weather', since that flag only has some effect if 'with_weather'
is true.